### PR TITLE
Only make request card appear clickable when js is enabled

### DIFF
--- a/ui/src/lib/components/custom/RequestCard.svelte
+++ b/ui/src/lib/components/custom/RequestCard.svelte
@@ -2,6 +2,7 @@
   import * as Card from "$lib/components/ui/card";
   import { Button } from "$lib/components/ui/button";
   import { goto } from "$app/navigation";
+  import { onMount } from "svelte";
 
   export let uuid: string;
   export let prompt: string;
@@ -18,12 +19,17 @@
   // make sure the first letter is capitalized
   strippedPrompt =
     strippedPrompt.charAt(0).toUpperCase() + strippedPrompt.slice(1);
+
+  // add the cursor-pointer and hover:bg-purple-200 classes to the root element
+  // we do it this way because we don't want these classes if javascript is disabled
+  onMount(() => {
+    const root = document.querySelector(".card-root");
+    if (!root) return;
+    root.classList.add("cursor-pointer", "hover:bg-purple-200");
+  });
 </script>
 
-<Card.Root
-  class="p-2 cursor-pointer hover:bg-purple-200"
-  on:click={() => goto(`/requests/${uuid}`)}
->
+<Card.Root class="p-2 card-root" on:click={() => goto(`/requests/${uuid}`)}>
   <Card.Content class="p-2">
     <Card.Title class="truncate pb-2">
       {strippedPrompt}


### PR DESCRIPTION
With JS disabled, the `on:click` of the request card won't execute, but prior to this PR, the card still appears clickable because we always set the hover bg color and cursor pointer attributes. This PR ensures we only set those attributes when JS is enabled.