### PR TITLE
use overflow auto instead of scroll

### DIFF
--- a/ui/src/lib/components/custom/MessageCard.svelte
+++ b/ui/src/lib/components/custom/MessageCard.svelte
@@ -67,7 +67,7 @@
       {/if}
     </Card.Title>
 
-    <div class="pt-4 overflow-x-scroll">
+    <div class="pt-4 overflow-x-auto">
       {#if isLoading}
         <div class="flex flex-col gap-2">
           <Skeleton class="w-full h-4" />


### PR DESCRIPTION
the old code causes the scrollbar to always be visible on some browsers; setting it to auto ensures that if the content isn't too wide, the scrollbar doesn't show