### PR TITLE
Fix the import paths

### DIFF
--- a/api/ask_astro/slack/app.py
+++ b/api/ask_astro/slack/app.py
@@ -1,10 +1,8 @@
 "Generates the slack app and the slack app handler."
 
 from ask_astro.config import FirestoreCollections, SlackAppConfig
-from ask_astro.stores import (
-    AsyncFirestoreInstallationStore,
-    AsyncFirestoreOAuthStateStore,
-)
+from ask_astro.stores.installation_store import AsyncFirestoreInstallationStore
+from ask_astro.stores.oauth_state_store import AsyncFirestoreOAuthStateStore
 from slack_bolt.adapter.sanic import AsyncSlackRequestHandler
 from slack_bolt.app.async_app import AsyncApp
 from slack_bolt.oauth.async_oauth_settings import AsyncOAuthSettings


### PR DESCRIPTION
- The ask astro website is breaking after the changes last night were merged: [error log details](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22ask-astro-dev%22%0Aresource.labels.location%20%3D%20%22us-central1%22%0A%20severity%3E%3DDEFAULT;pinnedLogId=2023-10-14T00:40:34.836628Z%2F6529e382000cc414f14fa80a;cursorTimestamp=2023-10-14T00:41:47.181973Z;aroundTime=2023-10-14T00:40:34.836628Z;duration=PT1H?hl=en&project=astronomer-success)
- Imports need to be fixed