### PR TITLE
fix(ui): fix 500 on empty prompt

### DIFF
--- a/ui/src/routes/+page.server.ts
+++ b/ui/src/routes/+page.server.ts
@@ -21,8 +21,6 @@ export const actions = {
     const prompt = formData.get("prompt")?.toString();
     const from_request_uuid = formData.get("from_request_uuid");
 
-    if (!prompt) throw new Error("Prompt is required");
-
     const body: { prompt: string; from_request_uuid?: string } = {
       prompt,
     };


### PR DESCRIPTION
## Why this fix?

If we send an empty string, the UI returns 500 error.


<img width="1214" alt="image" src="https://github.com/astronomer/ask-astro/assets/5144808/a29730dc-ebfd-4afe-befb-86429e4f95be">

## After this fix

The AI asks what it can help which seems to be a more user-friendly response

<img width="1197" alt="image" src="https://github.com/astronomer/ask-astro/assets/5144808/378f9101-b8bc-42d2-9aef-7cbfee3a565d">

closes: #82 
