### PR TITLE
ci(circleci): setup deploy-docs job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,3 +111,6 @@ workflows:
       - deploy-docs:
           requires:
             - build-docs
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
           command: pre-commit run --all-files
 
   build-docs:
-    description: "Build docs check (the actual publishing is handled by .readthedocs.yaml)"
+    description: "Build docs"
     executor:
       name: docker-executor
     steps:
@@ -68,6 +68,32 @@ jobs:
       - run:
           name: Run Sphinx
           command: poetry run inv docs.build
+      - persist_to_workspace:
+          root: docs/_build
+          paths: [html]
+
+  deploy-docs:
+    docker:
+      - image: node:8.10.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: docs/_build
+      - run:
+          name: Disable jekyll builds
+          command: touch docs/_build/html/.nojekyll
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+            git config user.email "airflow-oss-bot@astronomer.io"
+            git config user.name "airflow-oss-bot"
+      - add_ssh_keys:
+          fingerprints:
+            - 26:04:e6:0d:ce:4c:79:c4:e6:46:62:3f:fa:4e:d2:33
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dotfiles --message "[skip ci] Updates" --dist docs/_build/html
 
 workflows:
   tests:
@@ -82,3 +108,6 @@ workflows:
           <<: *all_branches_and_version_tag
       - build-docs:
           <<: *all_branches_and_version_tag
+      - deploy-docs:
+          requires:
+            - build-docs


### PR DESCRIPTION
Close: #122 


I think the last step we need is 

> Now, we need to upload the public key to GitHub so that it knows to trust a connection from CircleCI initiated with our private key. We head to https://github.com/jklukas/docs-on-gh-pages/settings/keys > Add Deploy Key, make the title of it “CircleCI write key” and paste in the contents of docs_deploy_key_rsa.pub. If you haven’t already deleted the private key, be extra careful you’re not accidentally copying from docs_deploy_key_rsa!

which might need @sunank200 's help on setting this up. (Scheduled messages with info and instructions for this setup on Slack)

ref: https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/