### PR TITLE
feat(api): MultiQueryRetriever with WeaviateHybridSearchRetriever

### DIFF
--- a/api/ask_astro/chains/answer_question.py
+++ b/api/ask_astro/chains/answer_question.py
@@ -11,17 +11,15 @@ from langchain.prompts import (
     MessagesPlaceholder,
     SystemMessagePromptTemplate,
 )
-from langchain.retrievers import MultiQueryRetriever
+from langchain.retrievers.weaviate_hybrid_search import WeaviateHybridSearchRetriever
 
-from ask_astro.clients.weaviate_ import docsearch
-from ask_astro.config import AzureOpenAIParams
+from ask_astro.clients.weaviate_ import client
+from ask_astro.config import AzureOpenAIParams, WeaviateConfig
 from ask_astro.settings import (
     CONVERSATIONAL_RETRIEVAL_LLM_CHAIN_DEPLOYMENT_NAME,
     CONVERSATIONAL_RETRIEVAL_LLM_CHAIN_TEMPERATURE,
     CONVERSATIONAL_RETRIEVAL_LOAD_QA_CHAIN_DEPLOYMENT_NAME,
     CONVERSATIONAL_RETRIEVAL_LOAD_QA_CHAIN_TEMPERATURE,
-    MULTI_QUERY_RETRIEVER_DEPLOYMENT_NAME,
-    MULTI_QUERY_RETRIEVER_TEMPERATURE,
 )
 
 with open("ask_astro/templates/combine_docs_chat_prompt.txt") as system_prompt_fd:
@@ -33,13 +31,12 @@ with open("ask_astro/templates/combine_docs_chat_prompt.txt") as system_prompt_f
     ]
 
 # Initialize a MultiQueryRetriever using AzureChatOpenAI and Weaviate.
-retriever = MultiQueryRetriever.from_llm(
-    llm=AzureChatOpenAI(
-        **AzureOpenAIParams.us_east,
-        deployment_name=MULTI_QUERY_RETRIEVER_DEPLOYMENT_NAME,
-        temperature=MULTI_QUERY_RETRIEVER_TEMPERATURE,
-    ),
-    retriever=docsearch.as_retriever(),
+retriever = WeaviateHybridSearchRetriever(
+    client=client,
+    index_name=WeaviateConfig.index_name,
+    text_key=WeaviateConfig.text_key,
+    attributes=WeaviateConfig.attributes,
+    create_schema_if_missing=True,
 )
 
 # Set up a ConversationalRetrievalChain to generate answers using the retriever.


### PR DESCRIPTION
Contradict to our earlier discussion; I suspect what we want to replace `WeaviateHybridSearchRetriever` with is `MultiQueryRetriever` instead of `ConversationalRetrievalChain`. However, it seems to perform even worse than the `MultiQueryRetriever` when it comes to **what is astro python sdk?**. astronomer-providers, airflow things seem to work. For testing, we can use the same set of env var and the exact same way to bring up the test env locally.

