### PR TITLE
fix(ui): fix h1 text alignment

### DIFF
--- a/ui/src/lib/components/custom/SourceCard.svelte
+++ b/ui/src/lib/components/custom/SourceCard.svelte
@@ -85,4 +85,9 @@
     color: #8c80b0;
     font-size: 15px;
   }
+
+  div.rendered-md :global(h1) {
+    text-align: left;
+  }
+
 </style>


### PR DESCRIPTION
Closes: #184

The root cause of this issue is that the default style of h1 contains `text-align: center;`. This PR overwrites this behavior

<img width="1324" alt="image" src="https://github.com/astronomer/ask-astro/assets/5144808/4d702987-b29b-4ee4-b87e-9d1e9892df34">
