### PR TITLE
Use sanic-limiter to throttle api requests

### DIFF
--- a/api/ask_astro/app.py
+++ b/api/ask_astro/app.py
@@ -10,6 +10,7 @@ from sanic_limiter import Limiter, get_remote_address
 from sanic_limiter.errors import RateLimitExceeded
 
 from ask_astro.rest.controllers import register_routes
+from ask_astro.rest.controllers.post_request import on_post_request
 from ask_astro.slack.app import app_handler, slack_app
 from ask_astro.slack.controllers import register_controllers
 
@@ -20,14 +21,14 @@ logger = getLogger(__name__)
 
 api = Sanic(name="ask_astro")
 
-requests_per_day = os.environ.get("API_REQUESTS_PER_DAY", "50")
-requests_per_hour = os.environ.get("API_REQUESTS_PER_HOUR", "20")
-requests_per_minute = os.environ.get("API_REQUESTS_PER_MINUTE", "10")
 limiter = Limiter(
     api,
     key_func=get_remote_address,
-    global_limits=[f"{requests_per_day} per day", f"{requests_per_hour} per hour", f"{requests_per_minute} per minute"],
 )
+requests_per_day = os.environ.get("API_REQUESTS_PER_DAY", "50")
+requests_per_hour = os.environ.get("API_REQUESTS_PER_HOUR", "20")
+requests_per_minute = os.environ.get("API_REQUESTS_PER_MINUTE", "10")
+requests_limit_value = f"{requests_per_day} per day, {requests_per_hour} per hour, {requests_per_minute} per minute"
 
 
 # route slack requests to the slack app
@@ -41,6 +42,7 @@ async def endpoint(req: Request):
 
 @api.exception(RateLimitExceeded)
 async def catch_rate_limit(request, exception):
+    logger.warning("Rate limit exceeded for IP %s at endpoint %s", request.ip, request.path)
     return json(
         {"error": "Rate limit exceeded"},
         status=429,
@@ -52,5 +54,15 @@ server_port = int(os.environ.get("PORT", 8080))
 register_controllers(slack_app)
 register_routes(api)
 
+
+# We want to rate limit requests to the /requests endpoint, but not to the other endpoints.
+# Hence, we use a separate explicit route registration here.
+@api.post("/requests", name="post_request")
+@limiter.limit(requests_limit_value, key_func=get_remote_address)
+async def post_request(req: Request):
+    """Handle POST requests to the /requests endpoint."""
+    return await on_post_request(req)
+
+
 if __name__ == "__main__":
-    api.run(host="0.0.0.0", port=server_port)
+    api.run(host="0.0.0.0", port=server_port, auto_reload=True)

--- a/api/ask_astro/app.py
+++ b/api/ask_astro/app.py
@@ -5,7 +5,9 @@ import logging
 import os
 from logging import getLogger
 
-from sanic import Request, Sanic
+from sanic import Request, Sanic, json
+from sanic_limiter import Limiter, get_remote_address
+from sanic_limiter.errors import RateLimitExceeded
 
 from ask_astro.rest.controllers import register_routes
 from ask_astro.slack.app import app_handler, slack_app
@@ -18,6 +20,15 @@ logger = getLogger(__name__)
 
 api = Sanic(name="ask_astro")
 
+requests_per_day = os.environ.get("API_REQUESTS_PER_DAY", "50")
+requests_per_hour = os.environ.get("API_REQUESTS_PER_HOUR", "20")
+requests_per_minute = os.environ.get("API_REQUESTS_PER_MINUTE", "10")
+limiter = Limiter(
+    api,
+    key_func=get_remote_address,
+    global_limits=[f"{requests_per_day} per day", f"{requests_per_hour} per hour", f"{requests_per_minute} per minute"],
+)
+
 
 # route slack requests to the slack app
 @api.get("/slack/oauth_redirect", name="oauth_redirect")
@@ -26,6 +37,14 @@ api = Sanic(name="ask_astro")
 async def endpoint(req: Request):
     """Forward requests to the Slack bolt handler."""
     return await app_handler.handle(req)
+
+
+@api.exception(RateLimitExceeded)
+async def catch_rate_limit(request, exception):
+    return json(
+        {"error": "Rate limit exceeded"},
+        status=429,
+    )
 
 
 server_port = int(os.environ.get("PORT", 8080))

--- a/api/ask_astro/rest/controllers/__init__.py
+++ b/api/ask_astro/rest/controllers/__init__.py
@@ -9,7 +9,6 @@ from sanic import Sanic, response
 
 from ask_astro.rest.controllers.get_request import on_get_request
 from ask_astro.rest.controllers.list_recent_requests import on_list_recent_requests
-from ask_astro.rest.controllers.post_request import on_post_request
 from ask_astro.rest.controllers.submit_feedback import on_submit_feedback
 
 logger = getLogger(__name__)
@@ -29,7 +28,6 @@ def register_routes(api: Sanic):
     routes: list[RouteConfig] = [
         RouteConfig(on_list_recent_requests, "/requests", ["GET"], "list_recent_requests"),
         RouteConfig(on_get_request, "/requests/<request_id:uuid>", ["GET"], "get_request"),
-        RouteConfig(on_post_request, "/requests", ["POST"], "post_request"),
         RouteConfig(on_submit_feedback, "/requests/<request_id:uuid>/feedback", ["POST"], "submit_feedback"),
     ]
 

--- a/tests/api/ask_astro/rest/controllers/conftest.py
+++ b/tests/api/ask_astro/rest/controllers/conftest.py
@@ -11,7 +11,9 @@ def app() -> Sanic:
     TestManager(app_instance)
 
     from ask_astro.rest.controllers import register_routes
+    from ask_astro.rest.controllers.post_request import on_post_request
 
+    app_instance.add_route(handler=on_post_request, uri="/requests", methods=["POST"], name="post_request")
     register_routes(app_instance)
 
     return app_instance

--- a/ui/src/routes/+page.server.ts
+++ b/ui/src/routes/+page.server.ts
@@ -7,13 +7,13 @@ export const load: PageServerLoad = async () => {
     const requests = await fetch(`${ASK_ASTRO_API_URL}/requests`);
 
     if (requests.status === 429) {
-      throw error(429, "Too many requests");
+      throw error(429, "You have made too many requests and exceeded the rate limit. Please wait for some time before trying again.");
     }
 
     return requests.json();
   } catch (err) {
     if (err.status === 429) {
-      throw error(429, "Too many requests");
+      throw error(429, "You have made too many requests and exceeded the rate limit. Please wait for some time before trying again.");
     }
     console.error(err);
 
@@ -50,7 +50,7 @@ export const actions = {
 
 
     if (response.status === 429) {
-      throw error(429, "Too many requests");
+      throw error(429, "You have made too many requests and exceeded the rate limit. Please wait for some time before trying again.");
     }
 
     const json = await response.json();

--- a/ui/src/routes/+page.server.ts
+++ b/ui/src/routes/+page.server.ts
@@ -48,6 +48,11 @@ export const actions = {
       },
     });
 
+
+    if (response.status === 429) {
+      throw error(429, "Too many requests");
+    }
+
     const json = await response.json();
     throw redirect(302, `/requests/${json.request_uuid}`);
   },

--- a/ui/src/routes/+page.server.ts
+++ b/ui/src/routes/+page.server.ts
@@ -1,13 +1,20 @@
 import { ASK_ASTRO_API_URL } from "$env/static/private";
-import { redirect } from "@sveltejs/kit";
+import {error, redirect} from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async () => {
   try {
     const requests = await fetch(`${ASK_ASTRO_API_URL}/requests`);
 
+    if (requests.status === 429) {
+      throw error(429, "Too many requests");
+    }
+
     return requests.json();
   } catch (err) {
+    if (err.status === 429) {
+      throw error(429, "Too many requests");
+    }
     console.error(err);
 
     return { requests: [] };

--- a/ui/src/routes/requests/[request_id]/+page.server.ts
+++ b/ui/src/routes/requests/[request_id]/+page.server.ts
@@ -14,10 +14,6 @@ export const load: PageServerLoad = async ({ params, depends }) => {
     throw error(404, "Request not found");
   }
 
-  if (request.status === 429) {
-    throw error(429, "Too many requests");
-  }
-
   return await request.json();
 };
 

--- a/ui/src/routes/requests/[request_id]/+page.server.ts
+++ b/ui/src/routes/requests/[request_id]/+page.server.ts
@@ -14,6 +14,10 @@ export const load: PageServerLoad = async ({ params, depends }) => {
     throw error(404, "Request not found");
   }
 
+  if (request.status === 429) {
+    throw error(429, "Too many requests");
+  }
+
   return await request.json();
 };
 


### PR DESCRIPTION
Throttles API requests based on user's IP address. 
With this PR, at the moment, we are only throttling `/requests` endpoint.

closes: #230