### PR TITLE
Improve readibility of list results

### DIFF
--- a/api/ask_astro/rest/controllers/get_request.py
+++ b/api/ask_astro/rest/controllers/get_request.py
@@ -3,6 +3,7 @@ Handles GET requests to the /ask/{question_id} endpoint.
 """
 from __future__ import annotations
 
+import re
 from logging import getLogger
 from uuid import UUID
 
@@ -14,6 +15,14 @@ from ask_astro.config import FirestoreCollections
 from ask_astro.models.request import AskAstroRequest
 
 logger = getLogger(__name__)
+
+
+def replace_single_newline_pattern_with_double_newline(text):
+    return re.sub(
+        r"(.+?)\n•",
+        lambda match: f"{match.group(1)}\n\n•" if "\n\n" not in match.group(1) else match.group(0),
+        text,
+    )
 
 
 @openapi.definition(response=AskAstroRequest.schema_json())
@@ -33,7 +42,9 @@ async def on_get_request(request: Request, request_id: UUID) -> json:
         if not request.exists:
             return json({"error": "Question not found"}, status=404)
 
-        return json(request.to_dict(), status=200)
+        request_dict = request.to_dict()
+        request_dict["response"] = replace_single_newline_pattern_with_double_newline(request_dict["response"])
+        return json(request_dict, status=200)
     except Exception as e:
         logger.error("Error fetching data for request %s: %s", request_id, e)
         return json({"error": "Internal Server Error"}, status=500)

--- a/tests/api/ask_astro/rest/controllers/test_get_requests.py
+++ b/tests/api/ask_astro/rest/controllers/test_get_requests.py
@@ -8,7 +8,7 @@ import pytest
 @pytest.mark.parametrize(
     "mock_exists, mock_data, expected_status, expected_response",
     [
-        (True, {"title": "Sample Question"}, 200, {"title": "Sample Question"}),
+        (True, {"title": "Sample Question", "response": "abc"}, 200, {"title": "Sample Question", "response": "abc"}),
         (False, None, 404, {"error": "Question not found"}),
         (None, None, 500, {"error": "Internal Server Error"}),
     ],


### PR DESCRIPTION
The UI renders the response from ask-astro pipeline as a markdown. 
For list items, the UI is able to render the list properly when the 
list items are separated by `\n\n` in the backend response, however 
when the list items are separated by a single `\n`, it fails to render 
them correctly. It's weird how OpenAI completion response at times 
adds a double new line chars and at times adds a single new line 
char to separate list items. However, I am adding a transform to 
convert single new line chars to double and when the response 
already contains two new line chars, not adding any extra new line char.

closes: #215