### PR TITLE
Log weaviate client error string joining

### DIFF
--- a/airflow/include/tasks/extract/utils/weaviate/ask_astro_weaviate_hook.py
+++ b/airflow/include/tasks/extract/utils/weaviate/ask_astro_weaviate_hook.py
@@ -465,7 +465,7 @@ class AskAstroWeaviateHook(WeaviateHook):
 
         if self.batch_errors:
             self.logger.error("Errors encountered during ingest.")
-            self.logger.error("\n".join(self.batch_errors))
+            self.logger.info(self.batch_errors)
             raise AirflowException("Errors encountered during ingest.")
 
     def _query_objects(self, value: Any, doc_key: str, class_name: str, uuid_column: str) -> set:


### PR DESCRIPTION
Currently, if ingestion fail we get some error and while logging if error is not string it throw error doing string concatenation 

**Log After this change**

```
[{'uuid': '0a89e583-6260-5c6c-9f9c-7b5a90db3d7b', 'errors': {'error': [{'message': "update vector: connection to: OpenAI API failed with status: 400 error: This model's maximum context length is 8192 tokens, however you requested 8236 tokens (8236 in your prompt; 0 for the completion). Please reduce your prompt; or completion length."}]}}, {'uuid': '5fa895fe-adc1-5303-8a1e-e9fe9b06d88b', 'errors': {'error': [{'message': "update vector: connection to: OpenAI API failed with status: 400 error: This model's maximum context length is 8192 tokens, however you requested 8290 tokens (8290 in your prompt; 0 for the completion). Please reduce your prompt; or completion length."}]}}]
```

**Log Before this change**
```
TypeError: sequence item 0: expected str instance, dict found
```