### PR TITLE
Log the errors in airflow for removal errors

### DIFF
--- a/airflow/include/tasks/extract/utils/weaviate/ask_astro_weaviate_hook.py
+++ b/airflow/include/tasks/extract/utils/weaviate/ask_astro_weaviate_hook.py
@@ -460,7 +460,7 @@ class AskAstroWeaviateHook(WeaviateHook):
                 )
                 if removal_errors:
                     self.logger.error("Errors encountered during removal.")
-                    self.logger.error("\n".join(removal_errors))
+                    self.logger.info(removal_errors)
                     raise AirflowException("Errors encountered during removal.")
 
         if self.batch_errors:


### PR DESCRIPTION
At the moment, when there is a removal failure, an error message is generated. During logging, if the error is not a string, a concatenation error occurs.

**Log After this change**

```
[{'uuid': '0a28831583-126978-5r19c-4929c-23b5ahs133d1b', 'errors': {'error': [{'message': "update vector: connection to: OpenAI API failed with status: 400 error: This model's maximum context length is 8192 tokens, however you requested 8236 tokens (8236 in your prompt; 0 for the completion). Please reduce your prompt; or completion length."}]}}, {'uuid': '5fa895fe-adc1-5303-8a1e-e9fe9b06d88b', 'errors': {'error': [{'message': "update vector: connection to: OpenAI API failed with status: 400 error: This model's maximum context length is 8192 tokens, however you requested 8290 tokens (8290 in your prompt; 0 for the completion). Please reduce your prompt; or completion length."}]}}]
```

**Log Before this change**
```
TypeError: sequence item 0: expected str instance, dict found
```