### PR TITLE
Send Slack alerts for DAG failures

### DIFF
--- a/airflow/dags/feedback/find_example_runs.py
+++ b/airflow/dags/feedback/find_example_runs.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Any
 
 from google.cloud import firestore
+from include.utils.slack import send_failure_notification
 from langchain.evaluation import StringEvaluator, load_evaluator
 from langchain.evaluation.schema import EvaluatorType
 from langsmith import Client
@@ -119,6 +120,9 @@ def process_run(run: dict[str, Any]):
     start_date=datetime(2023, 1, 1),
     default_args=default_args,
     catchup=False,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def find_example_runs():
     begin = EmptyOperator(task_id="begin")

--- a/airflow/dags/ingestion/ask-astro-forum-load.py
+++ b/airflow/dags/ingestion/ask-astro-forum-load.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -29,6 +31,9 @@ def get_astro_forum_content():
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_astro_forum():
     from include.tasks import split

--- a/airflow/dags/ingestion/ask-astro-load-airflow-docs.py
+++ b/airflow/dags/ingestion/ask-astro-load-airflow-docs.py
@@ -1,6 +1,8 @@
 import os
 from datetime import datetime
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -23,6 +25,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_airflow_docs():
     """

--- a/airflow/dags/ingestion/ask-astro-load-astro-cli.py
+++ b/airflow/dags/ingestion/ask-astro-load-astro-cli.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -20,6 +22,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_astro_cli_docs():
     """

--- a/airflow/dags/ingestion/ask-astro-load-astro-sdk.py
+++ b/airflow/dags/ingestion/ask-astro-load-astro-sdk.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -30,6 +32,9 @@ def get_astro_sdk_content():
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_astro_sdk():
     _import_data = WeaviateDocumentIngestOperator.partial(

--- a/airflow/dags/ingestion/ask-astro-load-astronomer-docs.py
+++ b/airflow/dags/ingestion/ask-astro-load-astronomer-docs.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -21,6 +23,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_astronomer_docs():
     """

--- a/airflow/dags/ingestion/ask-astro-load-astronomer-provider.py
+++ b/airflow/dags/ingestion/ask-astro-load-astronomer-provider.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -30,6 +32,9 @@ def get_provider_content():
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_astronomer_providers():
     """

--- a/airflow/dags/ingestion/ask-astro-load-blogs.py
+++ b/airflow/dags/ingestion/ask-astro-load-blogs.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -22,6 +24,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_blogs():
     """

--- a/airflow/dags/ingestion/ask-astro-load-github.py
+++ b/airflow/dags/ingestion/ask-astro-load-github.py
@@ -1,6 +1,8 @@
 import datetime
 import os
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -31,6 +33,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_github():
     """

--- a/airflow/dags/ingestion/ask-astro-load-registry.py
+++ b/airflow/dags/ingestion/ask-astro-load-registry.py
@@ -1,6 +1,8 @@
 import os
 from datetime import datetime
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -20,6 +22,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_registry():
     """

--- a/airflow/dags/ingestion/ask-astro-load-slack.py
+++ b/airflow/dags/ingestion/ask-astro-load-slack.py
@@ -1,6 +1,8 @@
 import os
 from datetime import datetime
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -30,6 +32,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_slack():
     """

--- a/airflow/dags/ingestion/ask-astro-load-stackoverflow.py
+++ b/airflow/dags/ingestion/ask-astro-load-stackoverflow.py
@@ -1,6 +1,8 @@
 import os
 from datetime import datetime
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
 
@@ -26,6 +28,9 @@ schedule_interval = "0 5 * * *" if ask_astro_env == "prod" else None
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_stackoverflow():
     """

--- a/airflow/dags/ingestion/ask-astro-load.py
+++ b/airflow/dags/ingestion/ask-astro-load.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 
 import pandas as pd
+from include.utils.slack import send_failure_notification
 
 from airflow.decorators import dag, task
 from airflow.exceptions import AirflowException
@@ -55,6 +56,9 @@ logger = logging.getLogger("airflow.task")
     catchup=False,
     is_paused_upon_creation=True,
     default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
 )
 def ask_astro_load_bulk():
     """

--- a/airflow/dags/monitor/external_trigger.py
+++ b/airflow/dags/monitor/external_trigger.py
@@ -1,10 +1,20 @@
 from datetime import datetime
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 
 
-@dag(schedule_interval="@daily", start_date=datetime(2023, 9, 27), catchup=False, is_paused_upon_creation=True)
+@dag(
+    schedule_interval="@daily",
+    start_date=datetime(2023, 9, 27),
+    catchup=False,
+    is_paused_upon_creation=True,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
+)
 def external_trigger_monitoring_dag():
     TriggerDagRunOperator(
         task_id="run_monitoring_dag",

--- a/airflow/dags/monitor/monitor_ingestion_dags.py
+++ b/airflow/dags/monitor/monitor_ingestion_dags.py
@@ -5,6 +5,8 @@ import os
 from datetime import datetime
 from typing import Any
 
+from include.utils.slack import send_failure_notification
+
 from airflow.decorators import dag, task
 from airflow.models import DagBag
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
@@ -57,7 +59,15 @@ def check_ingestion_dags(**context: Any):
         ).execute(context=context)
 
 
-@dag(schedule_interval="@daily", start_date=datetime(2023, 9, 27), catchup=False, is_paused_upon_creation=True)
+@dag(
+    schedule_interval="@daily",
+    start_date=datetime(2023, 9, 27),
+    catchup=False,
+    is_paused_upon_creation=True,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
+)
 def monitor_ingestion_dags():
     check_ingestion_dags()
 

--- a/airflow/include/utils/slack.py
+++ b/airflow/include/utils/slack.py
@@ -1,0 +1,15 @@
+import os
+
+from airflow.providers.slack.notifications.slack import send_slack_notification
+
+AIRFLOW__WEBSERVER__BASE_URL = os.environ.get("AIRFLOW__WEBSERVER__BASE_URL", "http://localhost:8080")
+ASK_ASTRO_ALERT_SLACK_CHANNEL_NAME = os.environ.get("ASK_ASTRO_ALERT_SLACK_CHANNEL_NAME", "#ask-astro-alert")
+ASK_ASTRO_ALERT_SLACK_CONN_ID = os.environ.get("ASK_ASTRO_ALERT_SLACK_CONN_ID", "slack_api_default")
+
+
+def send_failure_notification(dag_id, execution_date):
+    dag_link = f"{AIRFLOW__WEBSERVER__BASE_URL}/dags/{dag_id}/grid?search={dag_id}"
+    notification_text = f":red_circle: The DAG <{dag_link}|{dag_id}> with execution date `{execution_date}` failed."
+    return send_slack_notification(
+        slack_conn_id=ASK_ASTRO_ALERT_SLACK_CONN_ID, channel=ASK_ASTRO_ALERT_SLACK_CHANNEL_NAME, text=notification_text
+    )


### PR DESCRIPTION
The PR adds `on_failure_callback` for all the Ask Astro DAGs 
to notify DAG failures to the desired alerts Slack channel by leveraging 
the Slack Notifier from the Apache Airflow Slack provider.
For the alerts to work, it will need a connection of type `slack` 
created in the deployment. If the connection ID for this connection 
is different than the default `slack_api_default`, then the 
connection ID needs to be set in the deployment as an environment 
variable named `ASK_ASTRO_ALERT_SLACK_CONN_ID`.

closes: #231