### PR TITLE
Return the source documents in same order for slackbot as per the response in the UI 

### DIFF
--- a/api/ask_astro/slack/controllers/mention.py
+++ b/api/ask_astro/slack/controllers/mention.py
@@ -51,13 +51,7 @@ async def send_answer(request: AskAstroRequest, say: AsyncSay, ts: str):
     """
     response = markdown_to_slack(request.response)
 
-    source_links = ", ".join(
-        f"<{link}|[{n_}]>"
-        for n_, link in enumerate(
-            {*[s.name for s in request.sources if s.name]},
-            start=1,
-        )
-    )
+    source_links = ", ".join(f"<{s.name}|[{n_}]>" for n_, s in enumerate(request.sources, start=1) if s.name)
 
     resp = get_blocks(
         "message.jinja2",


### PR DESCRIPTION
- Add a fix so that the Slackbot should receive the source documents in the same order as they appear in the UI.

closes: #250 

Tested it here:
<img width="1443" alt="Screenshot 2024-01-10 at 9 47 42 PM" src="https://github.com/astronomer/ask-astro/assets/8670962/21368f01-1b75-4c57-bf26-16ade05fb390">
<img width="978" alt="Screenshot 2024-01-10 at 9 48 07 PM" src="https://github.com/astronomer/ask-astro/assets/8670962/791a860a-90ff-4953-adf3-8e5538f4384c">

Slack request: [https://ankit-test-group.slack.com/archives/C061F4LR4KT/p1704903223475919](https://ankit-test-group.slack.com/archives/C061F4LR4KT/p1704903223475919)
Web UI request: [https://f9c33f8b.ask-astro.pages.dev/requests/48c82d1e-afd1-11ee-a80f-42004e494300](https://f9c33f8b.ask-astro.pages.dev/requests/48c82d1e-afd1-11ee-a80f-42004e494300)