### PR TITLE
check if dictionary has a response key on_get_request

### DIFF
--- a/api/ask_astro/rest/controllers/get_request.py
+++ b/api/ask_astro/rest/controllers/get_request.py
@@ -43,7 +43,8 @@ async def on_get_request(request: Request, request_id: UUID) -> json:
             return json({"error": "Question not found"}, status=404)
 
         request_dict = request.to_dict()
-        request_dict["response"] = replace_single_newline_pattern_with_double_newline(request_dict["response"])
+        if request_dict and "response" in request_dict and request_dict["response"] is not None:
+            request_dict["response"] = replace_single_newline_pattern_with_double_newline(request_dict["response"])
         return json(request_dict, status=200)
     except Exception as e:
         logger.error("Error fetching data for request %s: %s", request_id, e)


### PR DESCRIPTION
After asking questions in ask.astronomer.io the UI broke after this [PR](https://github.com/astronomer/ask-astro/pull/240) as there is no check for `"response"` key in the returned dictionary [here](https://github.com/astronomer/ask-astro/blob/main/api/ask_astro/rest/controllers/get_request.py#L46)

Added the check for the "response" key in the dictionary in the API.

Tested with the following screenshot:

<img width="1719" alt="Screenshot 2024-01-16 at 4 24 58 PM" src="https://github.com/astronomer/ask-astro/assets/8670962/3a06a613-2ff4-4d3a-a63d-c1ef2627fb03">

close: #266 