### PR TITLE
Fix MultiQueryRetriever Prompt Rewording Inconsistent Formatting Error

### DIFF
--- a/api/ask_astro/chains/answer_question.py
+++ b/api/ask_astro/chains/answer_question.py
@@ -17,6 +17,7 @@ from langchain.retrievers.document_compressors import CohereRerank, LLMChainFilt
 from langchain.retrievers.weaviate_hybrid_search import WeaviateHybridSearchRetriever
 
 from ask_astro.chains.custom_llm_filter_prompt import custom_llm_chain_filter_prompt_template
+from ask_astro.chains.custom_llm_output_lines_parser import CustomLineListOutputParser
 from ask_astro.clients.weaviate_ import client
 from ask_astro.config import AzureOpenAIParams, CohereConfig, WeaviateConfig
 from ask_astro.settings import (
@@ -68,6 +69,8 @@ multi_query_retriever = MultiQueryRetriever.from_llm(
     prompt=user_question_rewording_prompt_template,
     retriever=hybrid_retriever,
 )
+# Override the default LineListOutputParser from LangChain
+multi_query_retriever.llm_chain.output_parser = CustomLineListOutputParser(max_lines=2)
 
 # Rerank
 cohere_reranker_compressor = CohereRerank(user_agent="langchain", top_n=CohereConfig.rerank_top_n)

--- a/api/ask_astro/chains/custom_llm_output_lines_parser.py
+++ b/api/ask_astro/chains/custom_llm_output_lines_parser.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from langchain.output_parsers.pydantic import PydanticOutputParser
 from langchain.retrievers.multi_query import LineList
@@ -11,9 +11,9 @@ class CustomLineListOutputParser(PydanticOutputParser):
     """
 
     max_lines: int = 2
-    max_line_len: Optional[int] = None
+    max_line_len: int | None = None
 
-    def __init__(self, max_lines: int = 2, max_line_len: Optional[int] = None) -> None:
+    def __init__(self, max_lines: int = 2, max_line_len: int | None = None) -> None:
         """
         Initialize CustomLineListOutputParser.
 
@@ -24,6 +24,15 @@ class CustomLineListOutputParser(PydanticOutputParser):
         self.max_lines = max_lines
         self.max_line_len = max_line_len
 
+    def _is_outpuit_line_valid(self, line: str) -> bool:
+        """
+        Check if a line of an llm output is a valid line.
+
+        :param line: llm output line to be used as input
+        :return: true if line is valid, false otherwise
+        """
+        return line != "" and (self.max_line_len is None or len(line) <= self.max_line_len)
+
     def parse(self, text: str) -> LineList:
         """
         Parse the input text into LineList.
@@ -32,7 +41,5 @@ class CustomLineListOutputParser(PydanticOutputParser):
         :return: parsed LineList
         """
         lines = text.strip().split("\n")
-        lines = [s for s in lines if s != "" and (self.max_line_len is None or len(s) <= self.max_line_len)][
-            : self.max_lines
-        ]
+        lines = [s for s in lines if self._is_outpuit_line_valid(s)][: self.max_lines]
         return LineList(lines=lines)

--- a/api/ask_astro/chains/custom_llm_output_lines_parser.py
+++ b/api/ask_astro/chains/custom_llm_output_lines_parser.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from langchain.output_parsers.pydantic import PydanticOutputParser
+from langchain.retrievers.multi_query import LineList
+
+
+class CustomLineListOutputParser(PydanticOutputParser):
+    """
+    Output parser for a list of lines with additional cleaning and fail checks.
+    This is a modified, less error prone implementation of the LineListOutputParser from LangChain.
+    """
+
+    max_lines: int = 2
+    max_line_len: Optional[int] = None
+
+    def __init__(self, max_lines: int = 2, max_line_len: Optional[int] = None) -> None:
+        """
+        Initialize CustomLineListOutputParser.
+
+        :param max_lines: maximum number of lines, default is 2
+        :param max_line_len: maximum length of lines, default is None
+        """
+        super().__init__(pydantic_object=LineList)
+        self.max_lines = max_lines
+        self.max_line_len = max_line_len
+
+    def parse(self, text: str) -> LineList:
+        """
+        Parse the input text into LineList.
+
+        :param text: input text to parse
+        :return: parsed LineList
+        """
+        lines = text.strip().split("\n")
+        lines = [s for s in lines if s != "" and (self.max_line_len is None or len(s) <= self.max_line_len)][
+            : self.max_lines
+        ]
+        return LineList(lines=lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,3 @@ fix = true
 
 [tool.ruff.isort]
 combine-as-imports = true
-required-imports = [ "from __future__ import annotations" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,4 @@ fix = true
 
 [tool.ruff.isort]
 combine-as-imports = true
+required-imports = [ "from __future__ import annotations" ]


### PR DESCRIPTION
### Description
- See https://github.com/astronomer/ask-astro/issues/272 for details of why the error occurs. This won't be explained again in this PR.
- This PR tackles the problem where the `LineListOutputParser` used in LangChain's `MultiQueryRetriever` not cleaning enough edge cases such as empty lines generated from LLM between reworded prompt lines causing an error thrown downstream (the empty line, along with other 2 reworded prompts are individually sent downstream to be used for vector db documents retrieval but an empty string will error out during this phase).

### Technical Changes
- Add `CustomLineListOutputParser`, a modified, less error prone implementation of the LineListOutputParser from LangChain. This CustomLineListOutputParser will get rid of lines that are empty lines and also limits the max number of lines or queries the multi-query retriever can generate through rewording.
- Manually replacing the `output_parser` inside the `llm_chain` of the multi-query retriever with the newly added CustomLineListOutputParser after its initialization.

### Tests
1. Tested to see previous user prompts that causes error downstream due to empty line between reworded prompts generated no longer an issue. I have attempted almost all the errored out prompts I can find and seems like this PR has fixed the issue. See one example below. 
 - [Langsmith link](https://smith.langchain.com/o/4942ae8b-e5be-4964-bb1f-7544886fa06d/projects/p/b66fb59c-2377-4587-a4c3-681163d84b97?columnVisibilityModel=%7B%22outputs%22%3Afalse%2C%22feedback_stats%22%3Atrue%2C%22reference_example%22%3Afalse%2C%22first_token_time%22%3Afalse%2C%22tags%22%3Afalse%2C%22metadata%22%3Afalse%7D&timeModel=%7B%22duration%22%3A%226h%22%7D&peek=0905ecbd-6f08-4b9e-9a18-02abe2cf6e21)
 - Before Fix Screenshot
![image](https://github.com/astronomer/ask-astro/assets/26350341/ac93a975-527a-4279-b1ec-0f3b24df2306)
 - After Fix Screenshot
![image](https://github.com/astronomer/ask-astro/assets/26350341/8e1e0441-a33b-4e00-83df-62a54154ac49)
2. Ran a sanity check on the original test question set. No errors or quality degradation. 

closes https://github.com/astronomer/ask-astro/issues/272