### PR TITLE
Add sveltekit-rate-limiter & Fix Rate Limiter Issue

### DIFF
--- a/api/ask_astro/app.py
+++ b/api/ask_astro/app.py
@@ -5,12 +5,9 @@ import logging
 import os
 from logging import getLogger
 
-from sanic import Request, Sanic, json
-from sanic_limiter import Limiter, get_remote_address
-from sanic_limiter.errors import RateLimitExceeded
+from sanic import Request, Sanic
 
 from ask_astro.rest.controllers import register_routes
-from ask_astro.rest.controllers.post_request import on_post_request
 from ask_astro.slack.app import app_handler, slack_app
 from ask_astro.slack.controllers import register_controllers
 
@@ -20,15 +17,6 @@ logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO"))
 logger = getLogger(__name__)
 
 api = Sanic(name="ask_astro")
-
-limiter = Limiter(
-    api,
-    key_func=get_remote_address,
-)
-requests_per_day = os.environ.get("API_REQUESTS_PER_DAY", "50")
-requests_per_hour = os.environ.get("API_REQUESTS_PER_HOUR", "20")
-requests_per_minute = os.environ.get("API_REQUESTS_PER_MINUTE", "10")
-requests_limit_value = f"{requests_per_day} per day, {requests_per_hour} per hour, {requests_per_minute} per minute"
 
 
 # route slack requests to the slack app
@@ -40,29 +28,10 @@ async def endpoint(req: Request):
     return await app_handler.handle(req)
 
 
-@api.exception(RateLimitExceeded)
-async def catch_rate_limit(request, exception):
-    logger.warning("Rate limit exceeded for IP %s at endpoint %s", request.ip, request.path)
-    return json(
-        {"error": "Rate limit exceeded"},
-        status=429,
-    )
-
-
 server_port = int(os.environ.get("PORT", 8080))
 
 register_controllers(slack_app)
 register_routes(api)
 
-
-# We want to rate limit requests to the /requests endpoint, but not to the other endpoints.
-# Hence, we use a separate explicit route registration here.
-@api.post("/requests", name="post_request")
-@limiter.limit(requests_limit_value, key_func=get_remote_address)
-async def post_request(req: Request):
-    """Handle POST requests to the /requests endpoint."""
-    return await on_post_request(req)
-
-
 if __name__ == "__main__":
-    api.run(host="0.0.0.0", port=server_port, auto_reload=True)
+    api.run(host="0.0.0.0", port=server_port)

--- a/api/ask_astro/rest/controllers/__init__.py
+++ b/api/ask_astro/rest/controllers/__init__.py
@@ -9,6 +9,7 @@ from sanic import Sanic, response
 
 from ask_astro.rest.controllers.get_request import on_get_request
 from ask_astro.rest.controllers.list_recent_requests import on_list_recent_requests
+from ask_astro.rest.controllers.post_request import on_post_request
 from ask_astro.rest.controllers.submit_feedback import on_submit_feedback
 
 logger = getLogger(__name__)
@@ -28,6 +29,7 @@ def register_routes(api: Sanic):
     routes: list[RouteConfig] = [
         RouteConfig(on_list_recent_requests, "/requests", ["GET"], "list_recent_requests"),
         RouteConfig(on_get_request, "/requests/<request_id:uuid>", ["GET"], "get_request"),
+        RouteConfig(on_post_request, "/requests", ["POST"], "post_request"),
         RouteConfig(on_submit_feedback, "/requests/<request_id:uuid>/feedback", ["POST"], "submit_feedback"),
     ]
 

--- a/tests/api/ask_astro/rest/controllers/conftest.py
+++ b/tests/api/ask_astro/rest/controllers/conftest.py
@@ -11,9 +11,7 @@ def app() -> Sanic:
     TestManager(app_instance)
 
     from ask_astro.rest.controllers import register_routes
-    from ask_astro.rest.controllers.post_request import on_post_request
 
-    app_instance.add_route(handler=on_post_request, uri="/requests", methods=["POST"], name="post_request")
     register_routes(app_instance)
 
     return app_instance

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,6 +28,7 @@
         "postcss-load-config": "^4.0.1",
         "svelte": "^4.0.5",
         "svelte-check": "^3.4.3",
+        "sveltekit-rate-limiter": "^0.4.3",
         "tailwindcss": "^3.3.2",
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
@@ -451,6 +452,15 @@
       "resolved": "https://registry.npmjs.org/@fontsource/fira-mono/-/fira-mono-4.5.10.tgz",
       "integrity": "sha512-bxUnRP8xptGRo8YXeY073DSpfK74XpSb0ZyRNpHV9WvLnJ7TwPOjZll8hTMin7zLC6iOp59pDZ8EQDj1gzgAQQ==",
       "dev": true
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
@@ -2208,6 +2218,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/sveltekit-rate-limiter": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/sveltekit-rate-limiter/-/sveltekit-rate-limiter-0.4.3.tgz",
+      "integrity": "sha512-BKkD2tvgyz5j4Fn1vt0y7FLF0zZ01f9thjWPGDb6fyX3tBXyMrtZ8ISK8M7zjz9Cik/2KrkvFtmldhXF6/hjqw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": "1.x || 2.x"
       }
     },
     "node_modules/tabbable": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
     "postcss-load-config": "^4.0.1",
     "svelte": "^4.0.5",
     "svelte-check": "^3.4.3",
+    "sveltekit-rate-limiter": "^0.4.3",
     "tailwindcss": "^3.3.2",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",

--- a/ui/src/routes/+page.server.ts
+++ b/ui/src/routes/+page.server.ts
@@ -26,15 +26,8 @@ export const load: PageServerLoad = async (event) => {
   try {
     const requests = await fetch(`${ASK_ASTRO_API_URL}/requests`);
 
-    if (requests.status === 429) {
-      throw error(429, "You have made too many requests and exceeded the rate limit. Please wait for some time before trying again.");
-    }
-
     return requests.json();
-  } catch (err: any) {
-    if (err.status === 429) {
-      throw error(429, "You have made too many requests and exceeded the rate limit. Please wait for some time before trying again.");
-    }
+  } catch (err) {
     console.error(err);
 
     return { requests: [] };
@@ -71,11 +64,6 @@ export const actions = {
         "Content-Type": "application/json",
       },
     });
-
-
-    if (response.status === 429) {
-      throw error(429, "You have made too many requests and exceeded the rate limit. Please wait for some time before trying again.");
-    }
 
     const json = await response.json();
     throw redirect(302, `/requests/${json.request_uuid}`);


### PR DESCRIPTION
### Description
- See https://github.com/astronomer/ask-astro/issues/268 for details of why the error occurs. This won't be explained again in this PR.
- TL;DR: svelte backend (cloudflare) is sitting in front of the GCP API therefore it is not possible to do IP based rate limiting in sanic. Instead, we must implement it in svelte for now.
- In production environment, I have set cookie rate limit to be 5 requests per minute, and IP based rate limit to be 100 per day using cloudflare's environment varables

### Technical Changes
- Add sveltekit-rate-limiter
- Revert the old PR that caused the rate limit issue (where all requests are misinterpreted as the same IP)

### Tests
Setup:
- In Cloudflare, I have set the dev environment to temporarily have these environment varaibles
![image](https://github.com/astronomer/ask-astro/assets/26350341/e054d730-08eb-4ce5-896c-df646c42cb6f)

1. Test cookie rate limiter. This should trigger after 5 requests using the same browser

https://github.com/astronomer/ask-astro/assets/26350341/0431cae3-b38d-479c-9b87-b1e7667286bd

2. Using incognito, we can continue to send requests without being blocked. But after 5 more requests we hit our IP based rate limit
<img width="1130" alt="image" src="https://github.com/astronomer/ask-astro/assets/26350341/c56b3a78-4fb2-4e6b-a891-f4e1ed037ba8">

3. Now, just to be safe, I used a different computer with VPN and reconnected to the same dev website. And confirmed that I can continue to send additional requests

closes #268 