### PR TITLE
Remove Azure US East Config and Credentials

### DIFF
--- a/api/ask_astro/chains/answer_question.py
+++ b/api/ask_astro/chains/answer_question.py
@@ -61,7 +61,7 @@ user_question_rewording_prompt_template = PromptTemplate(
 )
 multi_query_retriever = MultiQueryRetriever.from_llm(
     llm=AzureChatOpenAI(
-        **AzureOpenAIParams.us_east,
+        **AzureOpenAIParams.us_east2,
         deployment_name=MULTI_QUERY_RETRIEVER_DEPLOYMENT_NAME,
         temperature=MULTI_QUERY_RETRIEVER_TEMPERATURE,
     ),
@@ -81,7 +81,7 @@ reranker_retriever = ContextualCompressionRetriever(
 # GPT-3.5 to check over relevancy of the remaining documents
 llm_chain_filter = LLMChainFilter.from_llm(
     AzureChatOpenAI(
-        **AzureOpenAIParams.us_east,
+        **AzureOpenAIParams.us_east2,
         deployment_name=CONVERSATIONAL_RETRIEVAL_LLM_CHAIN_DEPLOYMENT_NAME,
         temperature=0.0,
     ),
@@ -97,7 +97,7 @@ answer_question_chain = ConversationalRetrievalChain(
     return_source_documents=True,
     question_generator=LLMChain(
         llm=AzureChatOpenAI(
-            **AzureOpenAIParams.us_east,
+            **AzureOpenAIParams.us_east2,
             deployment_name=CONVERSATIONAL_RETRIEVAL_LLM_CHAIN_DEPLOYMENT_NAME,
             temperature=CONVERSATIONAL_RETRIEVAL_LLM_CHAIN_TEMPERATURE,
         ),

--- a/api/ask_astro/clients/weaviate_.py
+++ b/api/ask_astro/clients/weaviate_.py
@@ -3,19 +3,10 @@ This module provides configurations and initializations for the Weaviate client,
 as well as text embeddings using the OpenAIEmbeddings from the LangChain library.
 """
 import weaviate
-from langchain.embeddings import OpenAIEmbeddings
 from langchain.vectorstores import Weaviate
 from weaviate import Client as WeaviateClient
 
-from ask_astro.config import AzureOpenAIParams, WeaviateConfig
-from ask_astro.settings import WEAVIATE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME, WEAVIATE_OPENAI_EMBEDDINGS_MODEL
-
-# Initialize OpenAI embeddings using the specified parameters.
-embeddings = OpenAIEmbeddings(
-    **AzureOpenAIParams.us_east,
-    deployment=WEAVIATE_OPENAI_EMBEDDINGS_DEPLOYMENT_NAME,
-    model=WEAVIATE_OPENAI_EMBEDDINGS_MODEL,
-)
+from ask_astro.config import WeaviateConfig
 
 # Configure and initialize the Weaviate client.
 client = WeaviateClient(

--- a/api/ask_astro/config.py
+++ b/api/ask_astro/config.py
@@ -21,9 +21,6 @@ class FirestoreCollections:
 class AzureOpenAIParams:
     """Contains the parameters for the Azure OpenAI API."""
 
-    us_east_raw = os.environ.get("AZURE_OPENAI_USEAST_PARAMS")
-    us_east = json.loads(us_east_raw) if us_east_raw else {}
-
     us_east2_raw = os.environ.get("AZURE_OPENAI_USEAST2_PARAMS")
     us_east2 = json.loads(us_east2_raw) if us_east2_raw else {}
 


### PR DESCRIPTION
### Description
- We have now migrated Ask Astro credentials into a single account on Azure. All OpenAI model deployments now use the same Azure endpoint (US East 2) and credentials. Therefore, the US East credentials environment variable and the config field is no longer relevant.

### Tests
- New credentials already tested in dev servers. `AZURE_OPENAI_USEAST_PARAMS` and `AZURE_OPENAI_USEAST2_PARAMS` was set to the be same
- In this branch, I removed the environment variable for `AZURE_OPENAI_USEAST_PARAMS` and the service still worked as expected.

Related to Issue #197 (Azure OpenAI migration, not OpenAI)