### PR TITLE
Add Ingestion for Cosmos Docs

### DIFF
--- a/airflow/dags/ingestion/ask-astro-load-cosmos-docs.py
+++ b/airflow/dags/ingestion/ask-astro-load-cosmos-docs.py
@@ -1,0 +1,53 @@
+import os
+from datetime import datetime
+
+from include.utils.slack import send_failure_notification
+
+from airflow.decorators import dag, task
+from airflow.providers.weaviate.operators.weaviate import WeaviateDocumentIngestOperator
+
+ask_astro_env = os.environ.get("ASK_ASTRO_ENV", "dev")
+
+_WEAVIATE_CONN_ID = f"weaviate_{ask_astro_env}"
+WEAVIATE_CLASS = os.environ.get("WEAVIATE_CLASS", "DocsDev")
+
+
+default_args = {"retries": 3, "retry_delay": 30}
+
+schedule_interval = os.environ.get("INGESTION_SCHEDULE", "0 5 * * 2") if ask_astro_env == "prod" else None
+
+
+@dag(
+    schedule_interval=schedule_interval,
+    start_date=datetime(2023, 9, 27),
+    catchup=False,
+    is_paused_upon_creation=True,
+    default_args=default_args,
+    on_failure_callback=send_failure_notification(
+        dag_id="{{ dag.dag_id }}", execution_date="{{ dag_run.execution_date }}"
+    ),
+)
+def ask_astro_load_airflow_docs():
+    """
+    This DAG performs incremental load for any new Cosmos docs. Initial load via ask_astro_load_bulk imported
+    data from a point-in-time data capture. By using the upsert logic of the weaviate_import decorator
+    any existing documents that have been updated will be removed and re-added.
+    """
+
+    from include.tasks import split
+    from include.tasks.extract import cosmos_docs
+
+    split_docs = task(split.split_html).expand(dfs=[cosmos_docs.extract_cosmos_docs()])
+
+    _import_data = WeaviateDocumentIngestOperator.partial(
+        class_name=WEAVIATE_CLASS,
+        existing="replace",
+        document_column="docLink",
+        batch_config_params={"batch_size": 1000},
+        verbose=True,
+        conn_id=_WEAVIATE_CONN_ID,
+        task_id="WeaviateDocumentIngestOperator",
+    ).expand(input_data=[split_docs])
+
+
+ask_astro_load_airflow_docs()

--- a/airflow/dags/ingestion/ask-astro-load.py
+++ b/airflow/dags/ingestion/ask-astro-load.py
@@ -329,6 +329,20 @@ def ask_astro_load_bulk():
         return [df]
 
     @task(trigger_rule="none_failed")
+    def extract_cosmos_docs():
+        from include.tasks.extract import cosmos_docs
+
+        parquet_file_path = "include/data/astronomer/cosmos/cosmos_docs.parquet"
+
+        try:
+            df = pd.read_parquet(parquet_file_path)
+        except Exception:
+            df = cosmos_docs.extract_cosmos_docs()[0]
+            df.to_parquet(parquet_file_path)
+
+        return [df]
+
+    @task(trigger_rule="none_failed")
     def extract_astronomer_docs():
         from include.tasks.extract.astro_docs import extract_astro_docs
 
@@ -390,6 +404,7 @@ def ask_astro_load_bulk():
     _astro_cli_docs = extract_astro_cli_docs()
     _extract_astro_providers_docs = extract_astro_provider_doc()
     _astro_forum_docs = extract_astro_forum_doc()
+    _cosmos_docs = extract_cosmos_docs()
 
     _get_schema = get_schema_and_process(schema_file="include/data/schema.json")
     _check_schema = check_schema(class_objects=_get_schema)
@@ -410,6 +425,7 @@ def ask_astro_load_bulk():
         _extract_astro_providers_docs,
         _astro_forum_docs,
         _astro_docs,
+        _cosmos_docs,
     ]
 
     python_code_tasks = [registry_dags_docs]

--- a/airflow/dags/ingestion/ask-astro-load.py
+++ b/airflow/dags/ingestion/ask-astro-load.py
@@ -156,6 +156,7 @@ def ask_astro_load_bulk():
                 "extract_astro_provider_doc",
                 "extract_astro_forum_doc",
                 "extract_astronomer_docs",
+                "extract_cosmos_docs",
             }
 
     @task(trigger_rule="none_failed")

--- a/airflow/include/tasks/extract/cosmos_docs.py
+++ b/airflow/include/tasks/extract/cosmos_docs.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import urllib.parse
+
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from weaviate.util import generate_uuid5
+
+from include.tasks.extract.utils.html_utils import get_internal_links
+
+
+def extract_cosmos_docs(docs_base_url: str = "https://astronomer.github.io/astronomer-cosmos/") -> list[pd.DataFrame]:
+    """
+    This task return a dataframe containing the extracted data for cosmos docs.
+    """
+
+    # we exclude the following docs which are not useful and/or too large for easy processing.
+    exclude_docs = [
+        "_sources",
+    ]
+
+    all_links = get_internal_links(docs_base_url, exclude_literal=exclude_docs)
+    html_links = {url for url in all_links if url.endswith(".html")}
+
+    docs_url_parts = urllib.parse.urlsplit(docs_base_url)
+    docs_url_base = f"{docs_url_parts.scheme}://{docs_url_parts.netloc}"
+    # make sure we didn't accidentally pickup any unrelated links in recursion
+    non_doc_links = {link if docs_url_base not in link else "" for link in html_links}
+    docs_links = html_links - non_doc_links
+
+    df = pd.DataFrame(docs_links, columns=["docLink"])
+
+    df["html_content"] = df["docLink"].apply(lambda url: requests.get(url).content)
+
+    # Only keep the main article content,
+    df["content"] = df["html_content"].apply(lambda x: str(BeautifulSoup(x, "html.parser").find(name="article")))
+
+    df["sha"] = df["content"].apply(generate_uuid5)
+    df["docSource"] = "cosmos docs"
+    df.reset_index(drop=True, inplace=True)
+
+    # column order matters for uuid generation
+    df = df[["docSource", "sha", "content", "docLink"]]
+
+    return [df]


### PR DESCRIPTION
### Description
- Need to ingest Cosmos Docs
- The website is really small (less than 50 pages of content), expecting minimum to no disuption to existing retrieval quality.

### Technical Details
- airflow/dags/ingestion/ask-astro-load-cosmos-docs.py: incremental ingestion that runs periodically
- airflow/dags/ingestion/ask-astro-load.py: added extract and ingest cosmos docs in bulk load
- airflow/include/tasks/extract/cosmos_docs.py: main file that handles the extraction from cosmos website
    - Note: only the main body of each page is extracted to minimize noise so the parsing logic is written tailoring to this data source (e.g. looking for `article` tag in the html body)


### Tests
- This is what the dataframe looks like after extracting and 
[df_dump.csv](https://github.com/astronomer/ask-astro/files/14121073/df_dump.csv)
- Airflow Ingestion UI confirmation that it is working for bulk load
![image](https://github.com/astronomer/ask-astro/assets/26350341/bd61f93a-32d0-425e-962a-7d6b49ae7544)


### Retrieval Quality Evaluation
- TBD



closes #277 