### PR TITLE
Upgrade/Change Weaviate Schema to Use `text-embedding-3-small`

### DIFF
--- a/airflow/include/data/schema.json
+++ b/airflow/include/data/schema.json
@@ -6,8 +6,7 @@
             "vectorizer": "text2vec-openai",
             "moduleConfig": {
                 "text2vec-openai": {
-                    "model": "ada",
-                    "modelVersion": "002",
+                    "model": "text-embedding-3-small",
                     "type": "text",
                     "vectorizeClassName": "False"
                 },


### PR DESCRIPTION
### Description
- [Original issue discussed here](https://github.com/astronomer/ask-astro/issues/286) 
- [Indirectly related issue about cost reduction (new model 5x cheaper but better accuracy](https://github.com/astronomer/ask-astro/issues/295)


### Technical Changes
- Just `schema.json` -- this changes the vectorizer used during ingestion AND during the retrieval
    - on ingestion a new index is created if it doesn't exist before. During retrieval this index's vectorizer is used for vectorizing user query

closes #286 