### PR TITLE
Bugfix: Added changes to update prompt for webapps

### DIFF
--- a/api/ask_astro/models/request.py
+++ b/api/ask_astro/models/request.py
@@ -57,10 +57,7 @@ class AskAstroRequest(BaseModel):
         False,
         description="Whether the request is an example",
     )
-    client: str = Field(
-        None,
-        description = "The client type used to send the request -- webapp/slack"
-    )
+    client: str = Field(None, description="The client type used to send the request -- webapp/slack")
 
     def to_firestore(self) -> dict[str, Any]:
         """
@@ -85,7 +82,7 @@ class AskAstroRequest(BaseModel):
             "response_received_at": self.response_received_at,
             "is_processed": self.is_processed,
             "is_example": self.is_example,
-            "client" : self.client,
+            "client": self.client,
         }
 
     @classmethod

--- a/api/ask_astro/models/request.py
+++ b/api/ask_astro/models/request.py
@@ -57,6 +57,10 @@ class AskAstroRequest(BaseModel):
         False,
         description="Whether the request is an example",
     )
+    client: str = Field(
+        None,
+        description = "The client type used to send the request -- webapp/slack"
+    )
 
     def to_firestore(self) -> dict[str, Any]:
         """
@@ -81,6 +85,7 @@ class AskAstroRequest(BaseModel):
             "response_received_at": self.response_received_at,
             "is_processed": self.is_processed,
             "is_example": self.is_example,
+            "client" : self.client,
         }
 
     @classmethod
@@ -105,4 +110,5 @@ class AskAstroRequest(BaseModel):
             response_received_at=response_dict.get("response_received_at"),
             is_processed=response_dict.get("is_processed", False),
             is_example=response_dict.get("is_example", False),
+            client=response_dict["client"],
         )

--- a/api/ask_astro/rest/controllers/post_request.py
+++ b/api/ask_astro/rest/controllers/post_request.py
@@ -89,8 +89,8 @@ async def on_post_request(request: Request) -> json:
             )
 
         # Set client types for web apps
-        if "client" in request and request["client"] is None:
-            request.client = "webapp"
+        if request.json and request.json["client"] is None:
+            request.json["client"] = "webapp"
         
         req = AskAstroRequest(
             uuid=uuid.uuid1(),

--- a/api/ask_astro/rest/controllers/post_request.py
+++ b/api/ask_astro/rest/controllers/post_request.py
@@ -87,7 +87,6 @@ async def on_post_request(request: Request) -> json:
                     },
                 )
             )
-        
         req = AskAstroRequest(
             uuid=uuid.uuid1(),
             prompt=request.json["prompt"],

--- a/api/ask_astro/rest/controllers/post_request.py
+++ b/api/ask_astro/rest/controllers/post_request.py
@@ -87,16 +87,13 @@ async def on_post_request(request: Request) -> json:
                     },
                 )
             )
-
-        # Set client types for web apps
-        if request.json and request.json["client"] is None:
-            request.json["client"] = "webapp"
         
         req = AskAstroRequest(
             uuid=uuid.uuid1(),
             prompt=request.json["prompt"],
             status="in_progress",
             messages=messages,
+            client = "webapp"
         )
 
         request.app.add_task(lambda: answer_question(req))

--- a/api/ask_astro/rest/controllers/post_request.py
+++ b/api/ask_astro/rest/controllers/post_request.py
@@ -88,6 +88,10 @@ async def on_post_request(request: Request) -> json:
                 )
             )
 
+        # Set client types for web apps
+        if "client" in request and request["client"] is None:
+            request.client = "webapp"
+        
         req = AskAstroRequest(
             uuid=uuid.uuid1(),
             prompt=request.json["prompt"],

--- a/api/ask_astro/rest/controllers/post_request.py
+++ b/api/ask_astro/rest/controllers/post_request.py
@@ -88,11 +88,7 @@ async def on_post_request(request: Request) -> json:
                 )
             )
         req = AskAstroRequest(
-            uuid=uuid.uuid1(),
-            prompt=request.json["prompt"],
-            status="in_progress",
-            messages=messages,
-            client = "webapp"
+            uuid=uuid.uuid1(), prompt=request.json["prompt"], status="in_progress", messages=messages, client="webapp"
         )
 
         request.app.add_task(lambda: answer_question(req))

--- a/api/ask_astro/services/questions.py
+++ b/api/ask_astro/services/questions.py
@@ -48,15 +48,13 @@ def _preprocess_request(request: AskAstroRequest) -> None:
     # take the most recent 10 question and answers in the history
     if len(request.messages) > PromptPreprocessingConfig.max_chat_history_len:
         request.messages = request.messages[-10:]
-    
     # Logic to change prompt for web apps
     if request.client is not None and request.client == "webapp":
         request.prompt = \
         request.prompt.replace("Slack","Markdown").\
             replace("Format links using this format: <URL|Text to display>. Examples: GOOD: <https://www.example.com|This message *is* a link>. BAD: [This message *is* a link](https://www.example.com).",\
                     "Format links using this format: [Text to display](URL). Examples: GOOD: [This message **is** a link](https://www.example.com). BAD: <https://www.example.com|This message **is** a link>.")
-    
-    # parse out backslack escape character to prevent hybrid search erroring out with invalid syntax string
+   # parse out backslack escape character to prevent hybrid search erroring out with invalid syntax string
     request.prompt = re.sub(r"(?<!\\)\\(?!\\)", "", request.prompt)
 
 

--- a/api/ask_astro/services/questions.py
+++ b/api/ask_astro/services/questions.py
@@ -50,11 +50,11 @@ def _preprocess_request(request: AskAstroRequest) -> None:
         request.messages = request.messages[-10:]
     # Logic to change prompt for web apps
     if request.client is not None and request.client == "webapp":
-        request.prompt = \
-        request.prompt.replace("Slack","Markdown").\
-            replace("Format links using this format: <URL|Text to display>. Examples: GOOD: <https://www.example.com|This message *is* a link>. BAD: [This message *is* a link](https://www.example.com).",\
-                    "Format links using this format: [Text to display](URL). Examples: GOOD: [This message **is** a link](https://www.example.com). BAD: <https://www.example.com|This message **is** a link>.")
-   # parse out backslack escape character to prevent hybrid search erroring out with invalid syntax string
+        request.prompt = request.prompt.replace("Slack", "Markdown").replace(
+            "Format links using this format: <URL|Text to display>. Examples: GOOD: <https://www.example.com|This message *is* a link>. BAD: [This message *is* a link](https://www.example.com).",
+            "Format links using this format: [Text to display](URL). Examples: GOOD: [This message **is** a link](https://www.example.com). BAD: <https://www.example.com|This message **is** a link>.",
+        )
+    # parse out backslack escape character to prevent hybrid search erroring out with invalid syntax string
     request.prompt = re.sub(r"(?<!\\)\\(?!\\)", "", request.prompt)
 
 

--- a/api/ask_astro/services/questions.py
+++ b/api/ask_astro/services/questions.py
@@ -48,6 +48,14 @@ def _preprocess_request(request: AskAstroRequest) -> None:
     # take the most recent 10 question and answers in the history
     if len(request.messages) > PromptPreprocessingConfig.max_chat_history_len:
         request.messages = request.messages[-10:]
+    
+    # Logic to change prompt for web apps
+    if request.client is not None and request.client == "webapp":
+        request.prompt = \
+        request.prompt.replace("Slack","Markdown").\
+            replace("Format links using this format: <URL|Text to display>. Examples: GOOD: <https://www.example.com|This message *is* a link>. BAD: [This message *is* a link](https://www.example.com).",\
+                    "Format links using this format: [Text to display](URL). Examples: GOOD: [This message **is** a link](https://www.example.com). BAD: <https://www.example.com|This message **is** a link>.")
+    
     # parse out backslack escape character to prevent hybrid search erroring out with invalid syntax string
     request.prompt = re.sub(r"(?<!\\)\\(?!\\)", "", request.prompt)
 

--- a/api/ask_astro/slack/controllers/mention.py
+++ b/api/ask_astro/slack/controllers/mention.py
@@ -112,7 +112,6 @@ async def on_mention(body: dict[str, Any], ack: AsyncAck, say: AsyncSay, client:
 
             if request.client is None:
                 request.client = "slack"
-
         await answer_question(request)
 
         async with TaskGroup() as tg:

--- a/api/ask_astro/slack/controllers/mention.py
+++ b/api/ask_astro/slack/controllers/mention.py
@@ -110,6 +110,9 @@ async def on_mention(body: dict[str, Any], ack: AsyncAck, say: AsyncSay, client:
                 if msg.get("type") == "message" and msg.get("ts") != ts
             ]
 
+            if request.client is None:
+                request.client = "slack"
+
         await answer_question(request)
 
         async with TaskGroup() as tg:

--- a/tests/api/ask_astro/models/test_request.py
+++ b/tests/api/ask_astro/models/test_request.py
@@ -17,6 +17,7 @@ def ask_astro_request_fixture():
         messages=[HumanMessage(content="Test message")],
         sources=[Source(name="Test Source", snippet="Test Snippet")],
         status="Test Status",
+        client="Test",
     )
     return request
 
@@ -50,6 +51,7 @@ def test_from_dict():
         "score": 5,
         "sent_at": 123456789,
         "response": None,
+        "client" : "Test"
     }
     request = AskAstroRequest.from_dict(data)
 
@@ -60,3 +62,4 @@ def test_from_dict():
     assert isinstance(request.messages[0], HumanMessage)
     assert len(request.sources) == 1
     assert isinstance(request.sources[0], Source)
+    assert request.client == "Test"

--- a/tests/api/ask_astro/models/test_request.py
+++ b/tests/api/ask_astro/models/test_request.py
@@ -51,7 +51,7 @@ def test_from_dict():
         "score": 5,
         "sent_at": 123456789,
         "response": None,
-        "client" : "Test"
+        "client": "Test",
     }
     request = AskAstroRequest.from_dict(data)
 


### PR DESCRIPTION
The PR makes the following changes:

1. Updates the request object to include a client variable to capture information on which client is sending the request. This information will be used to update the prompt & also for capturing metrics on requests per client type. Currently there are two client types - slack & webapp
2. For each of the client types - slack and webapp, we add conditions to update the relevant request variable
3. When the request is received from a webapp, then the prompt to LLM is updated to specify that we must return the result in markdown format