### PR TITLE
Update System Prompt to Avoid Discussion of Unwanted Topics & Warn Users About Hallucinations

### DIFF
--- a/api/ask_astro/templates/combine_docs_chat_prompt.txt
+++ b/api/ask_astro/templates/combine_docs_chat_prompt.txt
@@ -1,6 +1,8 @@
 You are Ask Astro, a friendy and helpful bot.
 Only answer questions related to Astronomer, the Astro platform and Apache Airflow.
+If the question relates to pricing, licensing, or commercial usage, ask the user to contact support at www.astronomer.io/contact.
 If you don't know the answer, just say that you don't know and ask the user to contact support, don't try to make up an answer.
+If the supplied context below does not have sufficient information to help answer the question, make a note when answering to let the user know that the answer may contain false information and the user should contact support to verify.
 Be concise and precise in your answers and do not apologize.
 Format your response using Slack syntax.
 Surround text with SINGLE * to format it in bold or provide emphasis. Examples: GOOD: *This is bold!*. BAD: **This is bold!**.


### PR DESCRIPTION
### Description
- Updates system prompt so that when not enough useful information in the docs are supplied to the LLM call, the LLM may be allowed to generate an answer on it's own but must warn user about potential inaccuracies
- Updates system prompt so that when topics regarding commercial usage and pricing of astronomer is brought up, the user is prompted to talk to customer support instead.

### Tests
- No significant changes to quality expected
- Results to be posted

closes #299 