### PR TITLE
[Hotfix] Fix Example Requests Cards Not Showing on UI

### DIFF
--- a/ui/src/routes/+page.server.ts
+++ b/ui/src/routes/+page.server.ts
@@ -35,8 +35,9 @@ export const load: PageServerLoad = async (event) => {
 
   try {
     const requests = await fetch(`${ASK_ASTRO_API_URL}/requests`);
+    const requests_json = await requests.json();
     return {
-      requests: await requests.json(),
+      requests: requests_json.requests,
       publicServiceAnnouncement: (health_status?.status === "maintenance" || !health_status) ? publicServiceAnnouncement : null,
     };
   } catch (err) {


### PR DESCRIPTION
### Descrption
* Fix Example Requests Cards Not Showing on UI
* Bug introduced in 0.3.0 release

### Test
This is already deployed and is working
<img width="1158" alt="image" src="https://github.com/astronomer/ask-astro/assets/26350341/0fd03863-df20-4417-8852-681e0988cbd0">
