### PR TITLE
[Hotfix] Slack Message History Not Being Passed Introduced by Another Hotfix During 0.3.1

### DIFF
--- a/api/ask_astro/services/questions.py
+++ b/api/ask_astro/services/questions.py
@@ -98,7 +98,8 @@ async def answer_question(request: AskAstroRequest) -> None:
                     lambda: slack_answer_question_chain(
                         {
                             "question": request.prompt,
-                            "chat_history": request.messages,
+                            "chat_history": [],
+                            "messages": request.messages,
                         },
                         metadata={"request_id": str(request.uuid), "client": str(request.client)},
                     )


### PR DESCRIPTION
Just 1 line of code change. PR is self explanatory.

This is causing an issue in prod and new branch has been tested where it does not error out