### PR TITLE
Remove Incorrect Exclude Doc Lines

### DIFF
--- a/airflow/include/tasks/extract/airflow_docs.py
+++ b/airflow/include/tasks/extract/airflow_docs.py
@@ -21,8 +21,6 @@ def extract_airflow_docs(docs_base_url: str) -> list[pd.DataFrame]:
     exclude_docs = [
         "changelog.html",
         "commits.html",
-        "docs/apache-airflow/stable/release_notes.html",
-        "docs/stable/release_notes.html",
         "_api",
         "_modules",
         "installing-providers-from-sources.html",


### PR DESCRIPTION
These lines have not been functional. The `docs_base_url` already has `docs` at the end,