### PR TITLE
docs: fix typo in prompt orchestration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ Ask Astro uses LangChain's `ConversationalRetrievalChain` to generate a response
 2. Embed each of 2 reworded prompts + original user prompt with OpenAI's embeddings model
 3. Retrieve up to 100 documents for each prompt from Weaviate using the embedded vectors from each prompt
 4. Using Cohere Reranker to rerank the combined up to 300 candidate pool of documents to only 8 most relevant documents
-5. Use a fast and cheapt LLM (`gpt-3.5-turbo`) to check relevancy of each of the 8 documents.
+5. Use a fast and cheap LLM (`gpt-3.5-turbo`) to check relevancy of each of the 8 documents.
 6. Combine the original user prompt with most relevant sources found, and make a final LLM call to generate an answer
 
 This generally works well. For prompt rewording, we use `gpt-3.5-turbo`, which runs very quickly and inexpensively. For the actual user-facing answer generation, we use `gpt-4o` to ensure high quality answers.


### PR DESCRIPTION
This PR fixes a misspelling in the Ask Astro documentation, specifically on step 5 under the **Prompt Orchestration** subsection.